### PR TITLE
Add AWS Cloudformation Deployment file for faizal-infra stack

### DIFF
--- a/cloudformation/deploy.yaml
+++ b/cloudformation/deploy.yaml
@@ -1,0 +1,4 @@
+template-file-path: cloudformation/cfn.yaml
+parameters: {}
+tags:
+  managed-by: cloudformation-git-sync


### PR DESCRIPTION
This pull request commits a CloudFormation [stack deployment file](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/git-sync-concepts-terms.html#git-sync-concepts-terms-depoyment-file) to your repository. AWS CloudFormation uses the `cloudformation/deploy.yaml` file to locate, track, and automatically update a stack that belongs to the `faizal-infra` template. When this pull request is merged, AWS CloudFormation tracks changes to this repository and applies updates to the stack and parameters that are defined in the file.

> :warning: When this change is merged, AWS CloudFormation tracks and syncs changes from this repository to the stack defined in `cloudformation/deploy.yaml`. Make sure to review it. You can disable syncing at any time in the AWS CloudFormation console.

#### How does it work?
Your `cloudformation/deploy.yaml` file contains the path from the root of your Git repository to your CloudFormation template as well as the parameters and tags for your stack. When changes are committed to your repository, CloudFormation automatically updates the stack, its parameters, and tags. 

#### How do I update the `cloudformation/deploy.yaml` file?
Edit your `cloudformation/deploy.yaml` file and commit the changes to your repository. Make sure that you commit the changes to the path and branch in the repository that are specified in the deployment file.